### PR TITLE
Remove "," on line 49 of _retina-sprites.scss

### DIFF
--- a/_retina-sprites.scss
+++ b/_retina-sprites.scss
@@ -46,7 +46,7 @@
       $pos: sprite-position($sprites2x, $name, -$pad * 2, -$pad * 2);
       background-image: sprite-url($sprites2x);
       background-position: nth($pos, 1) nth($pos, 2) / 2;
-      @include background-size(ceil(image-width(sprite-path($sprites2x)) / 2), auto);
+      @include background-size(ceil(image-width(sprite-path($sprites2x)) / 2) auto);
       //  sprite-path() returns the path of the generated sprite sheet, which
       //  image-width() calculates the width of. the ceil() is in place in case
       //  you have sprites that have an odd-number of pixels in width

--- a/demo/scss/utilities/_retina-sprites.scss
+++ b/demo/scss/utilities/_retina-sprites.scss
@@ -46,7 +46,7 @@
       $pos: sprite-position($sprites2x, $name, -$pad * 2, -$pad * 2);
       background-image: sprite-url($sprites2x);
       background-position: nth($pos, 1) nth($pos, 2) / 2;
-      @include background-size(ceil(image-width(sprite-path($sprites2x)) / 2), auto);
+      @include background-size(ceil(image-width(sprite-path($sprites2x)) / 2) auto);
       //  sprite-path() returns the path of the generated sprite sheet, which
       //  image-width() calculates the width of. the ceil() is in place in case
       //  you have sprites that have an odd-number of pixels in width


### PR DESCRIPTION
No "," into background-size property. 
Causing problems on some browsers. Bug seen on Android 2.3.5. 

Relatively to the MDN documentation : https://developer.mozilla.org/en-US/docs/CSS/background-size

Updates :
@include background-size(ceil(image-width(sprite-path($sprites2x)) / 2), auto);
==>
@include background-size(ceil(image-width(sprite-path($sprites2x)) / 2) auto);
