### PR TITLE
Fix for Firefox post version 16

### DIFF
--- a/_retina-sprites.scss
+++ b/_retina-sprites.scss
@@ -41,7 +41,7 @@
     padding: $pad;
   }
   
-  @media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-device-pixel-ratio: 1.5) {
+  @media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
     & {
       $pos: sprite-position($sprites2x, $name, -$pad * 2, -$pad * 2);
       background-image: sprite-url($sprites2x);


### PR DESCRIPTION
Following the advice posted here:

https://developer.mozilla.org/en-US/docs/CSS/Media_queries#-moz-device-pixel-ratio

and here:

http://www.w3.org/blog/CSS/2012/06/14/unprefix-webkit-device-pixel-ratio/

I've added the `min-resolution` declaration to the media query to make it work with modern Firefox editions.
