### PR TITLE
Divide retina x-position by 2 as well

### DIFF
--- a/_retina-sprites.scss
+++ b/_retina-sprites.scss
@@ -45,7 +45,7 @@
     & {
       $pos: sprite-position($sprites2x, $name, -$pad * 2, -$pad * 2);
       background-image: sprite-url($sprites2x);
-      background-position: nth($pos, 1) nth($pos, 2) / 2;
+      background-position: nth($pos, 1) / 2 nth($pos, 2) / 2;
       @include background-size(ceil(image-width(sprite-path($sprites2x)) / 2) auto);
       //  sprite-path() returns the path of the generated sprite sheet, which
       //  image-width() calculates the width of. the ceil() is in place in case
@@ -55,14 +55,14 @@
         $name_hover: $name + _hover;    // create myButton_hover and assign it
         &:hover{
           $pos: sprite-position($sprites2x, $name_hover, -$pad * 2, -$pad * 2);
-          background-position: nth($pos, 1) nth($pos, 2) / 2;
+          background-position: nth($pos, 1) / 2 nth($pos, 2) / 2;
         }
       }
       @if $active == true {
         $name_active: $name + _active;    // create myButton_active and assign it
         &:active{
           $pos: sprite-position($sprites2x, $name_active, -$pad * 2, -$pad * 2);
-          background-position: nth($pos, 1) nth($pos, 2) / 2;
+          background-position: nth($pos, 1) / 2 nth($pos, 2) / 2;
         }
       }
     }


### PR DESCRIPTION
Only the y-position in the background-position is being divided by two for retina sprites. Divide the x-position by two as well.
