### PR TITLE
Allow multiple $sprites declarations

### DIFF
--- a/_retina-sprites.scss
+++ b/_retina-sprites.scss
@@ -2,7 +2,7 @@
 @import "compass/css3/background-size";      // Include helper to calc background size
 
 
-@mixin retina-sprite($name, $hover: false, $active: false) {
+@mixin retina-sprite($name, $sprites, $sprites2x, $hover: false, $active: false) {
   @include _retina-sprite($name, $sprites, $sprites2x, $hover, $active);
 }
 


### PR DESCRIPTION
Hi Adam. The current helper only allows one $sprites declaration.

I usually have multiple sections in my apps where I'd like separate sprites files. For example, I'd like to be able to do this:

```
$ecommerce-sprites: sprite-map("ecommerce/sprites/*.png");
$ecommerce-sprites2x: sprite-map("ecommerce-retina/sprites/*.png");
$movie-sprites: sprite-map("movie/sprites/*.png");
$movie-sprites2x: sprite-map("movie-retina/sprites/*.png");

.paypal-btn {
  @include retina-sprite(paypal-btn, $ecommerce-sprites, $ecommerce-sprites2x);
}
.shopping-cart-btn {
  @include retina-sprite(shopping-cart-btn, $ecommerce-sprites, $ecommerce-sprites2x);
}

.play-icon {
  @include retina-sprite(play-icon, $movie-sprites, $movie-sprites2x);
}
.view-trailer-btn {
  @include retina-sprite(view-trailer-btn, $movie-sprites, $movie-sprites2x);
}
```

I was wondering if you'd like to merge this.

It would be cool if it would just use "$sprites" if it wasn't set; as well as appending "2x" to the name of the $sprites value if the $sprites2x parameter isn't defined; but that's beyond me at the moment.
